### PR TITLE
Filter cached coordinates from Tabs Tracker

### DIFF
--- a/payload_fields_parser.go
+++ b/payload_fields_parser.go
@@ -215,6 +215,25 @@ func extractFromRoot(packet *types.TtnMapperUplinkMessage, data map[string]inter
 		}
 	}
 
+	// Tabs Tracker provides a gnss_fix flag to indicate that the provided coordinates are cached and not valid for
+	// mapping purposes.
+	// https://github.com/SensationalSystems/smart_building_sensors_decoder/blob/master/gps.js
+	gnssFixKeys := [...]string{"gnss_fix"}
+	for _, v := range gnssFixKeys {
+		if val, ok := data[v]; ok {
+
+			switch val.(type) {
+			case bool:
+				if val == false {
+					return errors.New("gnss_fix is false - ignoring measurement")
+				}
+
+			default:
+				// type can not be handled
+			}
+		}
+	}
+
 	if val, ok := data["provider"]; ok {
 		packet.TtnMProvider = val.(string)
 	}


### PR DESCRIPTION
tkerby on Slack 2019-10-26 11:46 AM
> Also, should we warn people not to use devices that cache gps position?
> I’ve noticed that some of the trackers like the tabs tracker will store the last gps position for power saving and continue to relay it for instance when indoors. This is done as the purpose is to track location rather than map ttn coverage.
> Luckily there is a flag to say if gnss is current but it means doing a clever decoder in ttn to drop data when its not.

https://github.com/SensationalSystems/smart_building_sensors_decoder/blob/master/gps.js