### PR TITLE
parser: add sats and hdop support to CayenneLLP

### DIFF
--- a/payload_fields_parser.go
+++ b/payload_fields_parser.go
@@ -56,6 +56,25 @@ func parseCayenneLpp(packet *types.TtnMapperUplinkMessage, data map[string]inter
 		}
 	}
 
+	// allow to set sats ad hdop via Cayenne LPP
+	// setting AnalogIn to 3.03 enables the checking for both values
+	// digitalInput7 is an integer and sets sats
+	// analogInput7 is a float and sets the hdop
+	if val, ok := data["analog_in_6"]; ok {
+		if val.(float64) == 3.03 {
+			if val, ok := data["digital_in_7"]; ok {
+				packet.AccuracySource = "sats"
+				packet.Satellites = val.(int32)
+			}
+
+			if val, ok := data["analog_in_7"]; ok {
+				packet.AccuracySource = "hdop"
+				packet.Hdop = val.(float64)
+			}
+		}
+
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The CayenneLLP GPS format does not support accuracy information, while
sensors commonly offer the number of satellites or hdop values. To
reflect those information additional data fields are required.

This commit adds support for both `sats` and `hdop` values by using the
CayenneLLP types AnalogIn and DigitalIn. To avoid interpreting values
meant for other purposes, the value reading is only enabled if AnalogIn6
is set to `3.03`, which is reasonably unlikely happen unintentionally.
If AnalogIn6 is set to `3.03` DigitalIn7 is interpret as `sats` and
`AnalogIn7` is interpret as `hdop`.

Signed-off-by: Paul Spooren <mail@aparcar.org>